### PR TITLE
Dict.get and dict.setdefault

### DIFF
--- a/penty/pentypes/builtins.py
+++ b/penty/pentypes/builtins.py
@@ -386,6 +386,30 @@ def dict_clear(base_ty, self_ty):
         raise TypeError
     return _Cst[None]
 
+def dict_get(base_ty, self_ty, key_ty, default_ty=None):
+    if self_ty is not base_ty:
+        raise TypeError
+    if default_ty is None:
+        default_ty = _Cst[None]
+
+    if default_ty is self_ty.__args__[1]:
+        return self_ty.__args__[1]
+    else:
+        return {self_ty.__args__[1], default_ty}
+
+def dict_setdefault(base_ty, self_ty, key_ty, default_ty=None):
+    if default_ty is None:
+        default_ty = _Cst[None]
+    else:
+        default_ty = _astype(default_ty)
+    if default_ty is self_ty.__args__[1]:
+        return dict_get(base_ty, self_ty, key_ty, default_ty)
+    else:
+        return (dict_get(base_ty, self_ty, key_ty, default_ty),
+                (self_ty, key_ty, default_ty),
+                (_Dict[self_ty.__args__[0], default_ty], key_ty, default_ty))
+
+
 def dict_fromkeys(iterable_ty, value_ty=None):
     from penty.penty import Types
 
@@ -402,6 +426,8 @@ def dict_instanciate(ty):
         '__bool__': _FT[lambda *args: bool],
         '__len__': _FT[lambda *args: int],
         'clear': _FT[lambda *args: dict_clear(ty, *args)],
+        'get': _FT[lambda *args: dict_get(ty, *args)],
+        'setdefault': _FT[lambda *args: dict_setdefault(ty, *args)],
     }
 
 _dict_attrs = {

--- a/tests/test_builtins.py
+++ b/tests/test_builtins.py
@@ -213,6 +213,26 @@ class TestDict(TestPenty):
                           pentyping.Dict[str, pentyping.Cst[None]],
                           env={'x': str})
 
+    def test_get(self):
+        self.assertIsType('x.get(1, y)', int,
+                          env={'x': pentyping.Dict[int, int],
+                               'y': int})
+        self.assertIsType('x.get(1, 0.)', {int, pentyping.Cst[0.]},
+                          env={'x': pentyping.Dict[int, int]})
+        self.assertIsType('x.get(1)', {int, pentyping.Cst[None]},
+                          env={'x': pentyping.Dict[int, int]})
+
+    def test_setdefault(self):
+        self.assertIsType('x.setdefault(1, 0)', int,
+                          env={'x': pentyping.Dict[int, int]})
+        self.assertIsType('x.setdefault(1)', {int, pentyping.Cst[None]},
+                          env={'x': pentyping.Dict[int, int]})
+        self.assertIsType('(x.setdefault(1), x)[1]',
+                          {pentyping.Dict[int, int],
+                           pentyping.Dict[int, pentyping.Cst[None]]},
+                          env={'x': pentyping.Dict[int, int]})
+
+
 class TestList(TestPenty):
 
     def test_append(self):


### PR DESCRIPTION
dict.setdefault is a tricky one, but we nailed it thanks to an update of the
"parameter update" system.

Basically a type description can return:

- a type if there's only one possible return type
- a type set if there are several possible return types
- a tuple containing a type (or type set) as first element, followed by any
  number of tuples describing updated signature to apply at call site