### PR TITLE
Test calling constexpr function with kwargs

### DIFF
--- a/penty/penty.py
+++ b/penty/penty.py
@@ -146,12 +146,16 @@ def expand_args(fty, args_ty, kwargs_ty):
         kwonlyargs = [arg.id for arg in node.args.kwonlyargs]
         kwarg = node.args.kwarg
 
-    if issubclass(fty, FT):
+    elif issubclass(fty, FT):
         func = fty.__args__[0]
         fullargspec = inspect.getfullargspec(func)
         args = fullargspec.args
         kwonlyargs = fullargspec.kwonlyargs
         kwarg = fullargspec.varkw
+
+    elif issubclass(fty, Type):
+        func = Types[fty.__args__[0]]['__init__']
+        return expand_args(func, args_ty, kwargs_ty)
 
     # FIXME: handle posonlyargs, defaults
     if len(args_ty) > len(args):

--- a/penty/pentypes/builtins.py
+++ b/penty/pentypes/builtins.py
@@ -36,8 +36,9 @@ def int_init(value=None, base=None):
     from penty.penty import Types
     if issubclass(value, (int, float, str)):
         return int
+
     if '__int__' in Types[value]:
-        return Types[value]['__int__'](value)
+        return Types[value]['__int__'](_astype(value))
     raise TypeError
 
 def int_make_binop(operator):

--- a/tests/test_expr.py
+++ b/tests/test_expr.py
@@ -60,6 +60,14 @@ class TestExpr(TestPenty):
         self.assertIsType('(lambda y: y)(y=x)', int, env={'x': int})
         self.assertIsType('(lambda x, y: x + y)(1., y=x)', float, env={'x': int})
         self.assertIsType('(lambda x, *, y: x + y)(1., y=x)', float, env={'x': int})
+        self.assertIsType('(lambda x, *, y: x + y)(1., y=2.)', pentyping.Cst[3.], env={'x': int})
+
+    def test_call_ty(self):
+        self.assertIsType('int()', pentyping.Cst[0])
+        self.assertIsType('int(x)', int, env={'x': int})
+        self.assertIsType('int(x, y)', int, env={'x': int, 'y': int})
+        self.assertIsType('int(1, base=x)', int, env={'x': int})
+        self.assertIsType('int("110", base=2)', pentyping.Cst[6])
 
     def test_ifexpr_ty(self):
         self.assertIsType('x if x else y',


### PR DESCRIPTION
As a side effect, fix int.__init__ implementation and handling of constructor
kwargs